### PR TITLE
Fix bounds and centralize

### DIFF
--- a/sequential_uuids.c
+++ b/sequential_uuids.c
@@ -59,12 +59,12 @@ uuid_sequence_nextval(PG_FUNCTION_ARGS)
 	unsigned char  *p;
 
 	/* some basic sanity checks */
-	if (block_size < 0)
+	if (block_size < 1)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("block size must be a positive integer")));
 
-	if (block_count < 0)
+	if (block_count < 1)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("number of blocks must be a positive integer")));

--- a/sequential_uuids.c
+++ b/sequential_uuids.c
@@ -70,8 +70,8 @@ uuid_sequence_nextval(PG_FUNCTION_ARGS)
 				 errmsg("number of blocks must be a positive integer")));
 
 	/* count the number of bytes to keep from the sequence value */
-	prefix_bytes = 0;
-	while (block_count > 1)
+	prefix_bytes = 1;
+	while (block_count > 256)
 	{
 		block_count /= 256;
 		prefix_bytes++;
@@ -158,8 +158,8 @@ uuid_time_nextval(PG_FUNCTION_ARGS)
 	val = (tv.tv_sec / interval_length);
 
 	/* count the number of bytes to keep from the timestamp */
-	prefix_bytes = 0;
-	while (interval_count > 1)
+	prefix_bytes = 1;
+	while (interval_count > 256)
 	{
 		interval_count /= 256;
 		prefix_bytes++;

--- a/sequential_uuids.c
+++ b/sequential_uuids.c
@@ -30,6 +30,55 @@ PG_MODULE_MAGIC;
 PG_FUNCTION_INFO_V1(uuid_sequence_nextval);
 PG_FUNCTION_INFO_V1(uuid_time_nextval);
 
+static
+Datum
+sequential_uuid(int64 val, int32 block_size, int32 count)
+{
+	pg_uuid_t	*uuid = palloc(sizeof(pg_uuid_t));
+	unsigned char	*p;
+	int		prefix_bytes;
+	int		i;
+
+	val /= block_size;
+
+	/* count the number of bytes to keep from the value */
+	prefix_bytes = 1;
+	while (count > 256)
+	{
+		count /= 256;
+		prefix_bytes++;
+	}
+
+	/* copy the desired number of (least significant) bytes as prefix */
+	p = (unsigned char *) &val;
+	for (i = 0; i < prefix_bytes; i++)
+		uuid->data[i] = p[prefix_bytes - 1 - i];
+
+	/* generate the remaining bytes as random (use strong generator) */
+	if(!pg_strong_random(uuid->data + prefix_bytes, UUID_LEN - prefix_bytes))
+		ereport(ERROR,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+				 errmsg("could not generate random values")));
+
+	/*
+	 * Set the UUID version flags according to "version 4" (pseudorandom)
+	 * UUID, see http://tools.ietf.org/html/rfc4122#section-4.4
+	 *
+	 * This does reduce the randomness a bit, because it determines the
+	 * value of certain bits, but that should be negligible (certainly
+	 * compared to the reduction due to prefix).
+	 *
+	 * UUID v4 is probably the safest choice here. There is v1 which is
+	 * time-based, but it includes MAC address (which we don't use) and
+	 * works with very special timestamp (starting at 1582 etc.). So we
+	 * just use v4 and claim this is pseudorandom.
+	 */
+	uuid->data[6] = (uuid->data[6] & 0x0f) | 0x40;	/* time_hi_and_version */
+	uuid->data[8] = (uuid->data[8] & 0x3f) | 0x80;	/* clock_seq_hi_and_reserved */
+
+	PG_RETURN_UUID_P(uuid);
+}
+
 /*
  * uuid_sequence_nextval
  *	generate sequential UUID using a sequence
@@ -49,14 +98,9 @@ PG_FUNCTION_INFO_V1(uuid_time_nextval);
 Datum
 uuid_sequence_nextval(PG_FUNCTION_ARGS)
 {
-	int				i;
-	int64			val;
 	Oid				relid = PG_GETARG_OID(0);
 	int32			block_size = PG_GETARG_INT32(1);
 	int32			block_count = PG_GETARG_INT32(2);
-	int64			prefix_bytes;
-	pg_uuid_t	   *uuid;
-	unsigned char  *p;
 
 	/* some basic sanity checks */
 	if (block_size < 1)
@@ -69,52 +113,11 @@ uuid_sequence_nextval(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("number of blocks must be a positive integer")));
 
-	/* count the number of bytes to keep from the sequence value */
-	prefix_bytes = 1;
-	while (block_count > 256)
-	{
-		block_count /= 256;
-		prefix_bytes++;
-	}
-
-	/*
-	 * Read the next value from the sequence and get rid of the least
-	 * significant bytes.
-	 */
-	val = nextval_internal(relid, true);
-	val /= block_size;
-
-	p = (unsigned char *) &val;
-
-	uuid = palloc(sizeof(pg_uuid_t));
-
-	/* copy the desired number of (least significant) bytes as prefix */
-	for (i = 0; i < prefix_bytes; i++)
-		uuid->data[i] = p[prefix_bytes - 1 - i];
-
-	/* generate the remaining bytes as random (use strong generator) */
-	if(!pg_strong_random(uuid->data + prefix_bytes, UUID_LEN - prefix_bytes))
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("could not generate random values")));
-
-	/*
-	 * Set the UUID version flags according to "version 4" (pseudorandom)
-	 * UUID, see http://tools.ietf.org/html/rfc4122#section-4.4
-	 *
-	 * This does reduce the randomness a bit, because it determines the
-	 * value of certain bits, but that should be negligible (certainly
-	 * compared to the reduction due to prefix).
-	 * 
-	 * UUID v4 is probably the safest choice here. There is v1 which is
-	 * time-based, but it includes MAC address (which we don't use) and
-	 * works with very special timestamp (starting at 1582 etc.). So we
-	 * just use v4 and claim this is pseudorandom.
-	 */
-	uuid->data[6] = (uuid->data[6] & 0x0f) | 0x40;	/* time_hi_and_version */
-	uuid->data[8] = (uuid->data[8] & 0x3f) | 0x80;	/* clock_seq_hi_and_reserved */
-
-	PG_RETURN_UUID_P(uuid);
+	return sequential_uuid(
+		/* Create sequential uuid using next value of sequence */
+		nextval_internal(relid, true),
+		block_size,
+		block_count);
 }
 
 /*
@@ -132,14 +135,9 @@ uuid_sequence_nextval(PG_FUNCTION_ARGS)
 Datum
 uuid_time_nextval(PG_FUNCTION_ARGS)
 {
-	int				i;
-	struct timeval	tv;
-	int64			val;
-	pg_uuid_t	   *uuid;
 	int32			interval_length = PG_GETARG_INT32(0);
 	int32			interval_count = PG_GETARG_INT32(1);
-	int64			prefix_bytes;
-	unsigned char  *p;
+	struct timeval	tv;
 
 	/* some basic sanity checks */
 	if (interval_length < 1)
@@ -155,45 +153,9 @@ uuid_time_nextval(PG_FUNCTION_ARGS)
 	if (gettimeofday(&tv, NULL) != 0)
 		elog(ERROR, "gettimeofday call failed");
 
-	val = (tv.tv_sec / interval_length);
-
-	/* count the number of bytes to keep from the timestamp */
-	prefix_bytes = 1;
-	while (interval_count > 256)
-	{
-		interval_count /= 256;
-		prefix_bytes++;
-	}
-
-	p = (unsigned char *) &val;
-
-	uuid = palloc(sizeof(pg_uuid_t));
-
-	/* copy the desired number of (least significant) bytes as prefix */
-	for (i = 0; i < prefix_bytes; i++)
-		uuid->data[i] = p[prefix_bytes - 1 - i];
-
-	/* generate the remaining bytes as random (use strong generator) */
-	if(!pg_strong_random(uuid->data + prefix_bytes, UUID_LEN - prefix_bytes))
-		ereport(ERROR,
-				(errcode(ERRCODE_INTERNAL_ERROR),
-				 errmsg("could not generate random values")));
-
-	/*
-	 * Set the UUID version flags according to "version 4" (pseudorandom)
-	 * UUID, see http://tools.ietf.org/html/rfc4122#section-4.4
-	 *
-	 * This does reduce the randomness a bit, because it determines the
-	 * value of certain bits, but that should be negligible (certainly
-	 * compared to the reduction due to prefix).
-	 * 
-	 * UUID v4 is probably the safest choice here. There is v1 which is
-	 * time-based, but it includes MAC address (which we don't use) and
-	 * works with very special timestamp (starting at 1582 etc.). So we
-	 * just use v4 and claim this is pseudorandom.
-	 */
-	uuid->data[6] = (uuid->data[6] & 0x0f) | 0x40;	/* time_hi_and_version */
-	uuid->data[8] = (uuid->data[8] & 0x3f) | 0x80;	/* clock_seq_hi_and_reserved */
-
-	PG_RETURN_UUID_P(uuid);
+	return sequential_uuid(
+		/* Create sequential uuid using current time in seconds */
+		tv.tv_sec,
+		interval_length,
+		interval_count);
 }


### PR DESCRIPTION
Three commits in this PR:

* First one corrects the bounds check in uuid_sequence_nextval(...) to match the other function and associated error.
* Second fixes the bounds checks when determining the number of prefix bytes to give at least 1-byte. Otherwise values 1-255 would end up with a prefix of length zero (i.e. no prefix).
* Third commit centralizes the logic between the two functions into a single sequential_uuid(...) helper. I've left the error bounds checks in the public facing functions to allow them to better match the external parameters rather than have to use a generic term (i.e. "*length of interval*" vs just "*length*" or "*size*"). Should not actually change anything as it's just a consolidation of logic. Last commit is probably easier to view on it's own rather than as a diff.

I think the least-significant-bytes logic needs to be updated as well. It's correct for little endian but would be backwards on a big endian machine as the higher order bytes would be copied. This PR does not fix that yet thought (I just noticed it while wrapping this up):

```C
/* copy the desired number of (least significant) bytes as prefix */
p = (unsigned char *) &val;
for (i = 0; i < prefix_bytes; i++)
	uuid->data[i] = p[prefix_bytes - 1 - i];
```

Rather than having the user specify a length or count, how about having the length/count parameter to each function be the number of bytes of prefix to replace (with a valid range of either 1-8 or 1-7)? Then the prefix assignment could be something like:

```C
/* copy the desired number of (least significant) bytes as prefix */
for (i = 0; i < prefix_bytes; i++) {
	uuid->data[i] = val % 256;
	val /= 256;
}
```

Alternatively keep the current signatures but do that translation internally. Feels cleaner to just expose the number bytes directly as regardless of how it rounds you'll end up using all of them (ex: a value of 1 or 256 still gives a 1-byte prefix).